### PR TITLE
Use function-local scope for shell variable in SHELL_FUNCTION template

### DIFF
--- a/lib/pro.rb
+++ b/lib/pro.rb
@@ -6,7 +6,7 @@ require "colored"
 SHELL_FUNCTION = <<END
 # pro cd function
 {{name}}() {
-  projDir=$(pro search $1)
+  local projDir=$(pro search $1)
   cd ${projDir}
 }
 END


### PR DESCRIPTION
Just a quick patch so that the `pd` shell function doesn't leak its projDir variable.
