### PR TITLE
insert a newline before shell functions

### DIFF
--- a/lib/pro.rb
+++ b/lib/pro.rb
@@ -4,6 +4,7 @@ require "fuzzy_match"
 require "colored"
 
 SHELL_FUNCTION = <<END
+
 # pro cd function
 {{name}}() {
   projDir=$(pro search $1)


### PR DESCRIPTION
If the user ends their existing shell script (.bashrc or .zshrc) without
a newline, then it can lead to an error. It is safer not to assume a
newline at the end but insert one anyway.
