### PR TITLE
Suggestion: If pd is executed without arguments, it cd's into $PRO_BASE

### DIFF
--- a/lib/pro.rb
+++ b/lib/pro.rb
@@ -7,8 +7,18 @@ SHELL_FUNCTION = <<END
 
 # pro cd function
 {{name}}() {
-  local projDir=$(pro search $1)
-  cd ${projDir}
+  if [ -z $1 ]
+  then
+      if [ -z $PRO_BASE ]
+      then
+          eval cd $(cat ~/.probase)
+      else
+          cd $PRO_BASE
+      fi
+  else
+      local projDir=$(pro search $1)
+      cd ${projDir}
+  fi
 }
 END
 


### PR DESCRIPTION
I modified the SHELL_FUNCTION string to have that functionality. I don't know if this is what should happen, but I find it to be quite useful if you want to quickly cd into your git directory.
